### PR TITLE
intializePool test and spec updated

### DIFF
--- a/x/gamm/keeper/pool_service.go
+++ b/x/gamm/keeper/pool_service.go
@@ -62,6 +62,9 @@ func (k Keeper) CalculateSpotPrice(
 // - Sets bank metadata for the LP denom
 // - Records total liquidity increase
 // - Calls the AfterPoolCreated hook
+//
+// After the gammKeeper set pool to the state, this function calls the AfterPoolCreated hook
+// which is responsible for createing a gauge for each pool’s lockable duration
 func (k Keeper) InitializePool(ctx sdk.Context, pool swaproutertypes.PoolI, sender sdk.AccAddress) (err error) {
 	// Mint the initial pool shares share token to the sender
 	err = k.MintPoolShareToAccount(ctx, pool, sender, pool.GetTotalShares())


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #3644

## What is the purpose of the change

Create a test for function ``initializePool`` in ``x/gamm`` module and update its spec.


## Brief Changelog

  -  Add ``TestInitializePool`` in ``pool_service_test.go``, which cover 2 cases: initialize pool with default assets (pass), initialize pool with empty sender (not pass)
  - If expect test case to pass, we check: make sure new pool exists and has minted the correct number of pool shares, tokenDenomMetadata set correctly and ``AfterPoolCreated`` hook works fine. 
