### PR TITLE
auto: code-gen upgrade handler v19

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,7 +21,7 @@
                 "OSMOSIS_E2E_SKIP_UPGRADE": "false",
                 "OSMOSIS_E2E_SKIP_CLEANUP": "true",
                 "OSMOSIS_E2E_SKIP_STATE_SYNC": "false",
-                "OSMOSIS_E2E_UPGRADE_VERSION": "v15",
+                "OSMOSIS_E2E_UPGRADE_VERSION": "v19",
                 "OSMOSIS_E2E_DEBUG_LOG": "false",
             },
             "preLaunchTask": "e2e-setup"

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ SDK_PACK := $(shell go list -m github.com/cosmos/cosmos-sdk | sed  's/ /\@/g')
 GO_VERSION := $(shell cat go.mod | grep -E 'go [0-9].[0-9]+' | cut -d ' ' -f 2)
 DOCKER := $(shell which docker)
 BUILDDIR ?= $(CURDIR)/build
-E2E_UPGRADE_VERSION := "v15"
+E2E_UPGRADE_VERSION := "v19"
 
 
 GO_MAJOR_VERSION = $(shell go version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f1)

--- a/app/app.go
+++ b/app/app.go
@@ -51,6 +51,7 @@ import (
 	v13 "github.com/osmosis-labs/osmosis/v14/app/upgrades/v13"
 	v14 "github.com/osmosis-labs/osmosis/v14/app/upgrades/v14"
 	v15 "github.com/osmosis-labs/osmosis/v14/app/upgrades/v15"
+	v19 "github.com/osmosis-labs/osmosis/v14/app/upgrades/v19"
 	v3 "github.com/osmosis-labs/osmosis/v14/app/upgrades/v3"
 	v4 "github.com/osmosis-labs/osmosis/v14/app/upgrades/v4"
 	v5 "github.com/osmosis-labs/osmosis/v14/app/upgrades/v5"
@@ -96,7 +97,7 @@ var (
 
 	// _ sdksimapp.App = (*OsmosisApp)(nil)
 
-	Upgrades = []upgrades.Upgrade{v4.Upgrade, v5.Upgrade, v7.Upgrade, v9.Upgrade, v11.Upgrade, v12.Upgrade, v13.Upgrade, v14.Upgrade, v15.Upgrade}
+	Upgrades = []upgrades.Upgrade{v4.Upgrade, v5.Upgrade, v7.Upgrade, v9.Upgrade, v11.Upgrade, v12.Upgrade, v13.Upgrade, v14.Upgrade, v15.Upgrade, v19.Upgrade}
 	Forks    = []upgrades.Fork{v3.Fork, v6.Fork, v8.Fork, v10.Fork}
 )
 

--- a/app/upgrades/v19/constants.go
+++ b/app/upgrades/v19/constants.go
@@ -1,0 +1,19 @@
+package v19
+
+import (
+	"github.com/osmosis-labs/osmosis/v14/app/upgrades"
+
+	store "github.com/cosmos/cosmos-sdk/store/types"
+)
+
+// UpgradeName defines the on-chain upgrade name for the Osmosis v19 upgrade.
+const UpgradeName = "v19"
+
+var Upgrade = upgrades.Upgrade{
+	UpgradeName:          UpgradeName,
+	CreateUpgradeHandler: CreateUpgradeHandler,
+	StoreUpgrades:        store.StoreUpgrades{
+		Added:   []string{},
+		Deleted: []string{},
+    },
+}

--- a/app/upgrades/v19/upgrades.go
+++ b/app/upgrades/v19/upgrades.go
@@ -1,0 +1,21 @@
+package v19
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+
+	"github.com/osmosis-labs/osmosis/v14/app/keepers"
+	"github.com/osmosis-labs/osmosis/v14/app/upgrades"
+)
+
+func CreateUpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+	bpm upgrades.BaseAppParamManager,
+	keepers *keepers.AppKeepers,
+) upgradetypes.UpgradeHandler {
+	return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		return mm.RunMigrations(ctx, configurator, fromVM)
+	}
+}

--- a/tests/e2e/containers/config.go
+++ b/tests/e2e/containers/config.go
@@ -24,10 +24,10 @@ const (
 	// It should be uploaded to Docker Hub. OSMOSIS_E2E_SKIP_UPGRADE should be unset
 	// for this functionality to be used.
 	previousVersionOsmoRepository = "osmolabs/osmosis-dev"
-	previousVersionOsmoTag        = "v14.x-de392d2b-1674667154"
+	previousVersionOsmoTag        = "v18.0.0"
 	// Pre-upgrade repo/tag for osmosis initialization (this should be one version below upgradeVersion)
 	previousVersionInitRepository = "osmolabs/osmosis-e2e-init-chain"
-	previousVersionInitTag        = "v14.x-f6813bcb-1674140667-manual"
+	previousVersionInitTag        = "v18.0.0"
 	// Hermes repo/version for relayer
 	relayerRepository = "osmolabs/hermes"
 	relayerTag        = "0.13.0"


### PR DESCRIPTION
Update report
- Created a new empty upgrade handler
- Increased E2E_UPGRADE_VERSION in Makefile by 1
- Increased OSMOSIS_E2E_UPGRADE_VERSION in .vscode/launch.json by 1